### PR TITLE
now loading working when info not stored in redux

### DIFF
--- a/src/components/logicComponents/Carousel.js
+++ b/src/components/logicComponents/Carousel.js
@@ -5,12 +5,11 @@ import { useHorizontalScroll } from 'hooks/useSideScroll';
 import LOADER from 'imgs/loader.gif';
 import { BsFillBookmarkFill } from 'react-icons/bs';
 
-export function Carousel({ movies, isLoading }) {
+export function Carousel({ movies, loading }) {
   const scrollRef = useHorizontalScroll();
   return (
     <div ref={scrollRef} className="Carousel-container">
-
-      {!!movies?.length ? (
+      {loading && !!movies?.length ? (
         movies.map(movie => {
           return (
             <Link

--- a/src/pages/Home/Homepage.js
+++ b/src/pages/Home/Homepage.js
@@ -16,9 +16,9 @@ export function HomePage() {
   const t = useTranslation();
   const cachingCategory = useSelector(state => state.movies.moviesData);
   const [buttonValue, setButtonValue] = useState('discover');
+  const [loader, setLoader] = useState(false);
   const [movies, setMovies] = useState([]);
-  const [trigger, { isLoading }] = useLazyMovieFetchQuery();
-
+  const [trigger] = useLazyMovieFetchQuery();
   const dispatch = useDispatch();
   const watchList = getWatchlist();
   const history = useHistory();
@@ -35,8 +35,10 @@ export function HomePage() {
           })
         );
       }
+
       setMovies(cachingCategory[buttonValue].data);
     })();
+    setLoader(cachingCategory[buttonValue]?.loaded);
   }, [buttonValue, cachingCategory, trigger, dispatch]);
 
   return (
@@ -60,7 +62,7 @@ export function HomePage() {
           </div>
           <div className="Homepage-container__carousel-container">
             {' '}
-            <Carousel isLoading={isLoading} movies={movies} />{' '}
+            <Carousel loading={loader} movies={movies} />{' '}
           </div>
           {!!watchList.length ? (
             <>


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->
https://trello.com/c/q6r3c0QU/9-show-loader-when-changing-movies-tabs

## What & Why:
<!--- Describe the changes being made and why they're useful --->
now, if the endpoints are not loaded, selecting a category, you are gonna see a loader

<!--- Screenshots are expected for UI changes... right? ಠ_ಠ --->


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [x] Safe to Revert *check this box if this PR can be reverted without incident*
